### PR TITLE
axum 初期API実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+debug/
+target/
+
+Cargo.lock
+
+**/*.rs.bk
+
+*.pdb

--- a/axum-train/Cargo.toml
+++ b/axum-train/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "axum-train"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+axum = "0.7.3"
+tokio = { version="1.35.1", features = ["full"] }
+tower = "0.4.13"
+hyper = { version="1.1.0", features = ["full"] }
+mime = "0.3.17"
+anyhow = "1.0.78"
+serde = { version="1.0.136", features=["derive"]}
+serde_json = "1.0.78"
+dotenv = "0.15.0"

--- a/axum-train/src/main.rs
+++ b/axum-train/src/main.rs
@@ -1,0 +1,29 @@
+use axum::{
+    extract::Extension,
+    routing::{delete, get, post},
+    Router,Json
+};
+use std::net::SocketAddr;
+// use std::{env, sync::Arc};
+// use dotenv::dotenv;
+// use hyper::header::CONTENT_TYPE;
+// use sqlx::{PgPool, FromRow};
+//use tower_http::cors::{Any, CorsLayer, Origin};
+
+#[tokio::main]
+async fn main() {
+    //dotenv().ok();
+    let app = Router::new().route("/", get(root));
+    // 最近のaxumが少し変わった模様
+    // let addr = SocketAddr::from(([0,0,0,1], 3000));
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    // axum::Server::bind(&addr)
+    //     .serve(app.into_make_service())
+    //     .await
+    //     .unwrap();
+    axum::serve(listener, app).await.unwrap();
+}
+
+async fn root() -> &'static str {
+    "200 ok"
+}


### PR DESCRIPTION
# 内容
初期APIの実装


# 備考
axumの使用が一部変更されていた模様
```
// 変更前
let app = Router::new().route("/", get(root));
let addr = SocketAddr::from(([0,0,0,0], 3000));
axum::Server::bind(&addr)
  .serve(app.into_make_service())
  .await
  .unwrap();

// 変更後
let app = ...
let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
axum::serve(listener, app).await.unwrap();
```